### PR TITLE
Add rectangle and triangle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Flags are standard SVGs placed in the `public/flags` directory. A flexible gener
 python3 create_flag.py COUNTRY_NAME -x WIDTH -y HEIGHT [options]
 ```
 
-The script accepts many options such as `--vertical`, `--horizontal`, `--circle`, `--cross`, `--star`, `--moon` and more. Generated files are written to `public/flags` by default. See `create_flag.py --help` for the full list of arguments and examples.
+The script accepts many options such as `--vertical`, `--horizontal`, `--circle`, `--cross`, `--star`, `--moon`, `--rect` and `--triangle`. Generated files are written to `public/flags` by default. See `create_flag.py --help` for the full list of arguments and examples.
 
 The helper script `generate_flag_array.sh` prints a JSON array of the available country codes based on the files in `public/flags`.
 


### PR DESCRIPTION
## Summary
- extend `create_flag.py` script to support rectangles and arbitrary triangles
- document new options in README

## Testing
- `python3 -m py_compile create_flag.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840c62a1b48832bbcc7fa9c4355b24e